### PR TITLE
Audio PR 7 : Last Batch Policy, stick_to_shard, shard_size & auto_reset

### DIFF
--- a/rocAL/include/api/rocal_api.h
+++ b/rocAL/include/api/rocal_api.h
@@ -50,9 +50,13 @@ THE SOFTWARE.
  * \param [in] cpu_thread_count number of cpu threads
  * \param [in] prefetch_queue_depth The depth of the prefetch queue.
  * \param [in] output_tensor_data_type RocalTensorOutputType: Defines whether the output of rocal tensor is FP32 or FP16.
+ * \param [in] last_batch_policy What to do with the last batch when there are not enough samples in the epoch to fully fill it
+ * \param [in] last_batch_padded Whether the last batch provided by DALI is padded with the last sample or it just wraps up.
+                                 In the conjunction with last_batch_policy it tells if the iterator returning last batch with 
+                                 data only partially filled with data from the current epoch is dropping padding samples or samples from the next epoch.
  * \return A \ref RocalContext - The context for the pipeline
  */
-extern "C" RocalContext ROCAL_API_CALL rocalCreate(size_t batch_size, RocalProcessMode affinity, int gpu_id = 0, size_t cpu_thread_count = 1, size_t prefetch_queue_depth = 3, RocalTensorOutputType output_tensor_data_type = RocalTensorOutputType::ROCAL_FP32);
+extern "C" RocalContext ROCAL_API_CALL rocalCreate(size_t batch_size, RocalProcessMode affinity, int gpu_id = 0, size_t cpu_thread_count = 1, size_t prefetch_queue_depth = 3, RocalTensorOutputType output_tensor_data_type = RocalTensorOutputType::ROCAL_FP32, RocalLastBatchPolicy last_batch_policy = RocalLastBatchPolicy::ROCAL_LAST_BATCH_FILL, bool last_batch_padded = false);
 
 /*!
  * \brief  rocalVerify function to verify the graph for all the inputs and outputs

--- a/rocAL/include/api/rocal_api_data_loaders.h
+++ b/rocAL/include/api/rocal_api_data_loaders.h
@@ -824,19 +824,23 @@ extern "C" RocalTensor ROCAL_API_CALL rocalJpegExternalFileSource(RocalContext p
                                                                   RocalDecoderType rocal_decoder_type = RocalDecoderType::ROCAL_DECODER_TJPEG,
                                                                   RocalExternalSourceMode external_source_mode = RocalExternalSourceMode::ROCAL_EXTSOURCE_FNAME);
 
-/// Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
-/// If the files are not in standard audio compression formats they will be ignored.
-/// \param context Rocal context
-/// \param source_path A NULL terminated char string pointing to the location on the disk
-/// \param source_file_list_path A NULL terminated char string pointing to the file list location on the disk
-/// \param shard_count Defines the parallelism level by internally sharding the input dataset and load/decode using multiple decoder/loader instances. Using shard counts bigger than 1 improves the load/decode performance if compute resources (CPU cores) are available.
-/// \param is_output Determines if the user wants the loaded audio to be part of the output or not.
-/// \param shuffle Determines if the user wants to shuffle the dataset or not.
-/// \param loop Determines if the user wants to indefinitely loops through audio or not.
-/// \param downmix If set to True, downmix all input channels to mono. If downmixing is turned on, the decoder output is 1D. If downmixing is turned off, it produces 2D output with interleaved channels incase of multichannel audio.
-/// \param max_frames The maximum frames of the decoded audio.
-/// \param max_channels The maximum channels of the decoded audio.
-/// \return Reference to the output audio
+/*! Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
+ * If the files are not in standard audio compression formats they will be ignored.
+ * \ingroup group_rocal_data_loaders
+ * \param [in] context Rocal context
+ * \param [in] source_path A NULL terminated char string pointing to the location on the disk
+ * \param [in] source_file_list_path A NULL terminated char string pointing to the file list location on the disk
+ * \param [in] shard_count Defines the parallelism level by internally sharding the input dataset and load/decode using multiple decoder/loader instances. Using shard counts bigger than 1 improves the load/decode performance if compute resources (CPU cores) are available.
+ * \param [in] is_output Determines if the user wants the loaded audio to be part of the output or not.
+ * \param [in] shuffle Determines if the user wants to shuffle the dataset or not.
+ * \param [in] loop Determines if the user wants to indefinitely loops through audio or not.
+ * \param [in] downmix If set to True, downmix all input channels to mono. If downmixing is turned on, the decoder output is 1D. If downmixing is turned off, it produces 2D output with interleaved channels incase of multichannel audio.
+ * \param [in] max_frames The maximum frames of the decoded audio.
+ * \param [in] max_channels The maximum channels of the decoded audio.
+ * \param [in] stick_to_shard Determines weather or not the dataset when sharded should stick to a single shards dataset or considered in a round robin fashion.
+ * \param [in] shard_size Provides the data-size of the shard for an iterator
+ * \return Reference to the output audio
+ */
 extern "C"  RocalTensor  ROCAL_API_CALL rocalAudioFileSource(RocalContext context,
                                                             const char* source_path,
                                                             const char* source_file_list_path,
@@ -846,7 +850,9 @@ extern "C"  RocalTensor  ROCAL_API_CALL rocalAudioFileSource(RocalContext contex
                                                             bool loop = false,
                                                             bool downmix = false,
                                                             unsigned max_frames = 1,
-                                                            unsigned max_channels = 1);
+                                                            unsigned max_channels = 1,
+                                                            bool stick_to_shard = false,
+                                                            int shard_size = -1);
 
 /// Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
 /// If the files are not in standard audio compression formats they will be ignored.

--- a/rocAL/include/api/rocal_api_data_loaders.h
+++ b/rocAL/include/api/rocal_api_data_loaders.h
@@ -824,7 +824,7 @@ extern "C" RocalTensor ROCAL_API_CALL rocalJpegExternalFileSource(RocalContext p
                                                                   RocalDecoderType rocal_decoder_type = RocalDecoderType::ROCAL_DECODER_TJPEG,
                                                                   RocalExternalSourceMode external_source_mode = RocalExternalSourceMode::ROCAL_EXTSOURCE_FNAME);
 
-/*! Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
+/*! \brief Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
  * If the files are not in standard audio compression formats they will be ignored.
  * \ingroup group_rocal_data_loaders
  * \param [in] context Rocal context
@@ -854,21 +854,22 @@ extern "C"  RocalTensor  ROCAL_API_CALL rocalAudioFileSource(RocalContext contex
                                                             bool stick_to_shard = false,
                                                             int shard_size = -1);
 
-/// Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
-/// If the files are not in standard audio compression formats they will be ignored.
-/// \param context Rocal context
-/// \param source_path A NULL terminated char string pointing to the location on the disk
-/// \param source_file_list_path A NULL terminated char string pointing to the file list location on the disk
-/// \param shard_id Shard id for this loader
-/// \param shard_count Defines the parallelism level by internally sharding the input dataset and load/decode using multiple decoder/loader instances. Using shard counts bigger than 1 improves the load/decode performance if compute resources (CPU cores) are available.
-/// \param is_output Determines if the user wants the loaded audio to be part of the output or not.
-/// \param shuffle Determines if the user wants to shuffle the dataset or not.
-/// \param loop Determines if the user wants to indefinitely loops through audio or not.
-/// \param downmix If set to True, downmix all input channels to mono. If downmixing is turned on, the decoder output is 1D. If downmixing is turned off, it produces 2D output with interleaved channels incase of multichannel audio.
-/// \param max_frames The maximum frames of the decoded audio.
-/// \param max_channels The maximum channels of the decoded audio.
-/// \param storage_type Determines the storage type
-/// \return Reference to the output audio
+/*! \brief Creates Audio file reader and decoder. It allocates the resources and objects required to read and decode audio files stored on the file systems. It has internal sharding capability to load/decode in parallel is user wants.
+ * If the files are not in standard audio compression formats they will be ignored.
+ * \param [in] context Rocal context
+ * \param [in] source_path A NULL terminated char string pointing to the location on the disk
+ * \param [in] source_file_list_path A NULL terminated char string pointing to the file list location on the disk
+ * \param [in] shard_id Shard id for this loader
+ * \param [in] shard_count Defines the parallelism level by internally sharding the input dataset and load/decode using multiple decoder/loader instances. Using shard counts bigger than 1 improves the load/decode performance if compute resources (CPU cores) are available.
+ * \param [in] is_output Determines if the user wants the loaded audio to be part of the output or not.
+ * \param [in] shuffle Determines if the user wants to shuffle the dataset or not.
+ * \param [in] loop Determines if the user wants to indefinitely loops through audio or not.
+ * \param [in] downmix If set to True, downmix all input channels to mono. If downmixing is turned on, the decoder output is 1D. If downmixing is turned off, it produces 2D output with interleaved channels incase of multichannel audio.
+ * \param [in] max_frames The maximum frames of the decoded audio.
+ * \param [in] max_channels The maximum channels of the decoded audio.
+ * \param [in] storage_type Determines the storage type
+ * \return Reference to the output audio
+ */
 extern "C"  RocalTensor  ROCAL_API_CALL rocalAudioFileSourceSingleShard(RocalContext p_context,
                                                                         const char* source_path,
                                                                         const char* source_file_list_path,

--- a/rocAL/include/api/rocal_api_info.h
+++ b/rocAL/include/api/rocal_api_info.h
@@ -129,4 +129,13 @@ extern "C" const char* ROCAL_API_CALL rocalGetErrorMessage(RocalContext rocal_co
  */
 extern "C" TimingInfo ROCAL_API_CALL rocalGetTimingInfo(RocalContext rocal_context);
 
+/*!
+ * \brief Retrieves the information about the size of the last batch.
+ * \ingroup group_rocal_info
+ * \param rocal_context
+ * \return The number of samples that were padded in adherence with last_batch_policy and last_batch_padded
+ */
+extern "C"  size_t  ROCAL_API_CALL rocalGetLastBatchPaddedSize(RocalContext rocal_context);
+
+
 #endif  // MIVISIONX_ROCAL_API_INFO_H

--- a/rocAL/include/api/rocal_api_types.h
+++ b/rocAL/include/api/rocal_api_types.h
@@ -395,4 +395,17 @@ enum RocalOutOfBoundsPolicy {
     TRIMTOSHAPE,
     ERROR
 };
+
+/*! \brief Tensor Last Batch Policies
+ *  \ingroup group_rocal_types
+ These policies the last batch policies determine the behavior when there are not enough samples in the epoch to fill the last batch
+        FILL - The last batch is filled by either repeating the last sample or by wrapping up the data set.
+        DROP - The last batch is dropped if when there are not enough samples from the current epoch.
+        PARTIAL - The last batch is partially filled with the remaining data from the current epoch, keeping the rest of the samples empty. (currently this policy works similar to FILL in rocAL, PARTIAL policy needs to handled from python end)
+ */
+enum RocalLastBatchPolicy {
+    ROCAL_LAST_BATCH_FILL = 0,
+    ROCAL_LAST_BATCH_DROP = 1,
+    ROCAL_LAST_BATCH_PARTIAL = 2
+};
 #endif  // MIVISIONX_ROCAL_API_TYPES_H

--- a/rocAL/include/loaders/audio/audio_loader.h
+++ b/rocAL/include/loaders/audio/audio_loader.h
@@ -54,6 +54,7 @@ class AudioLoader : public LoaderModule {
     void shut_down() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override {THROW("feed_external_input is not compatible with this implementation")}
+    size_t last_batch_padded_size() override;
 
    private:
     bool is_out_of_data();
@@ -82,4 +83,6 @@ class AudioLoader : public LoaderModule {
     size_t _remaining_audio_count;  //!< How many audios are there yet to be loaded
     int _device_id;
     size_t _max_decoded_samples, _max_decoded_channels;
+    RocalBatchPolicy _last_batch_policy;
+    bool last_batch_padded;
 };

--- a/rocAL/include/loaders/audio/audio_loader_sharded.h
+++ b/rocAL/include/loaders/audio/audio_loader_sharded.h
@@ -43,6 +43,7 @@ class AudioLoaderSharded : public LoaderModule {
     void shut_down() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override { THROW("feed_external_input is not compatible with this implementation") }
+    size_t last_batch_padded_size() override;
 
    private:
     void increment_loader_idx();

--- a/rocAL/include/loaders/audio/audio_read_and_decode.h
+++ b/rocAL/include/loaders/audio/audio_read_and_decode.h
@@ -57,6 +57,7 @@ class AudioReadAndDecode {
         std::vector<float> &original_sample_rates);
     //! returns timing info or other status information
     Timing timing();
+    size_t last_batch_padded_size();
 
    private:
     std::vector<std::shared_ptr<AudioDecoder>> _decoder;

--- a/rocAL/include/loaders/audio/node_audio_loader.h
+++ b/rocAL/include/loaders/audio/node_audio_loader.h
@@ -41,10 +41,13 @@ class AudioLoaderNode : public Node {
     /// \param load_batch_count Defines the quantum count of the Audios to be loaded. It's usually equal to the user's batch size.
     /// \param mem_type Memory type, host or device
     /// \param meta_data_reader Determines the meta-data information
+    /// \param stick_to_shard Determines after each epoch if the pipeline advances to the next shard to increase the entropy of the data that is seen by this pipeline or not.
+    /// \param shard_size Number of samples in the shard for the wrapped pipeline. Providing -1 means that the iterator will work until StopIteration is raised from the inside of iterator.
     /// The loader will repeat Audios if necessary to be able to have Audios in multiples of the load_batch_count,
     /// for example if there are 10 Audios in the dataset and load_batch_count is 3, the loader repeats 2 Audios as if there are 12 Audios available.
     void init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &source_file_list, StorageType storage_type,
-              DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader);
+              DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
+              RocalBatchPolicy last_batch_policy = RocalBatchPolicy::BATCH_FILL, bool last_batch_padded = false, bool stick_to_shard = false, signed shard_size=-1);
     std::shared_ptr<LoaderModule> get_loader_module();
 
    protected:

--- a/rocAL/include/loaders/audio/node_audio_loader_single_shard.h
+++ b/rocAL/include/loaders/audio/node_audio_loader_single_shard.h
@@ -43,7 +43,8 @@ class AudioLoaderSingleShardNode : public Node {
     /// for example if there are 10 Audios in the dataset and load_batch_count is 3, the loader repeats 2 Audios as if there are 12 Audios available.
     void init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &source_file_list,
               StorageType storage_type, DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type,
-              std::shared_ptr<MetaDataReader> meta_data_reader);
+              std::shared_ptr<MetaDataReader> meta_data_reader, RocalBatchPolicy _last_batch_policy = RocalBatchPolicy::BATCH_FILL, 
+              bool last_batch_padded = false, bool stick_to_shard = false, signed shard_size = -1);
     std::shared_ptr<LoaderModule> get_loader_module();
 
    protected:

--- a/rocAL/include/loaders/image/cifar10_data_loader.h
+++ b/rocAL/include/loaders/image/cifar10_data_loader.h
@@ -49,6 +49,7 @@ class CIFAR10DataLoader : public LoaderModule {
     void set_batch_random_bbox_crop_coords(std::vector<std::vector<float>> batch_crop_coords);
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char *>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override {}
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     void increment_loader_idx();

--- a/rocAL/include/loaders/image/image_loader.h
+++ b/rocAL/include/loaders/image/image_loader.h
@@ -55,6 +55,7 @@ class ImageLoader : public LoaderModule {
     void shut_down() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override;
+    size_t last_batch_padded_size() override;
 
    private:
     bool is_out_of_data();
@@ -63,7 +64,6 @@ class ImageLoader : public LoaderModule {
     std::shared_ptr<ImageReadAndDecode> _image_loader;
     LoaderModuleStatus update_output_image();
     LoaderModuleStatus load_routine();
-
     std::shared_ptr<RandomBBoxCrop_MetaDataReader> _randombboxcrop_meta_data_reader = nullptr;
     Tensor* _output_tensor;
     std::vector<std::string> _output_names;  //!< image name/ids that are stores in the _output_image
@@ -91,4 +91,6 @@ class ImageLoader : public LoaderModule {
     size_t _max_tensor_width, _max_tensor_height;
     bool _external_source_reader = false;  //!< Set to true if external source reader
     bool _external_input_eos = false;      //!< Set to true for last batch for the sequence
+    RocalBatchPolicy _last_batch_policy;
+    bool last_batch_padded;
 };

--- a/rocAL/include/loaders/image/image_loader_sharded.h
+++ b/rocAL/include/loaders/image/image_loader_sharded.h
@@ -47,6 +47,7 @@ class ImageLoaderSharded : public LoaderModule {
     void shut_down() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char *>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override;
+    size_t last_batch_padded_size() override;
 
    private:
     void increment_loader_idx();

--- a/rocAL/include/loaders/image/image_read_and_decode.h
+++ b/rocAL/include/loaders/image/image_read_and_decode.h
@@ -69,6 +69,7 @@ class ImageReadAndDecode {
 
     //! returns timing info or other status information
     Timing timing();
+    size_t last_batch_padded_size();
 
    private:
     std::vector<std::shared_ptr<Decoder>> _decoder;

--- a/rocAL/include/loaders/image/node_fused_jpeg_crop.h
+++ b/rocAL/include/loaders/image/node_fused_jpeg_crop.h
@@ -42,7 +42,8 @@ class FusedJpegCropNode : public Node {
     /// for example if there are 10 images in the dataset and load_batch_count is 3, the loader repeats 2 images as if there are 12 images available.
     void init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type,
               DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
-              unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio);
+              unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio, 
+              RocalBatchPolicy _last_batch_policy = RocalBatchPolicy::BATCH_FILL, bool last_batch_padded = false);
 
     std::shared_ptr<LoaderModule> get_loader_module();
 

--- a/rocAL/include/loaders/image/node_fused_jpeg_crop_single_shard.h
+++ b/rocAL/include/loaders/image/node_fused_jpeg_crop_single_shard.h
@@ -39,7 +39,8 @@ class FusedJpegCropSingleShardNode : public Node {
     /// for example if there are 10 images in the dataset and load_batch_count is 3, the loader repeats 2 images as if there are 12 images available.
     void init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type,
               DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
-              unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio);
+              unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio, 
+              RocalBatchPolicy last_batch_policy = RocalBatchPolicy::BATCH_FILL, bool last_batch_padded = false);
 
     std::shared_ptr<LoaderModule> get_loader_module();
 

--- a/rocAL/include/loaders/image/node_image_loader.h
+++ b/rocAL/include/loaders/image/node_image_loader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +40,8 @@ class ImageLoaderNode : public Node {
     /// The loader will repeat images if necessary to be able to have images in multiples of the load_batch_count,
     /// for example if there are 10 images in the dataset and load_batch_count is 3, the loader repeats 2 images as if there are 12 images available.
     void init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, const std::map<std::string, std::string> feature_key_map, StorageType storage_type, DecoderType decoder_type, bool shuffle, bool loop,
-              size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig = false, const char *prefix = "", unsigned sequence_length = 0, unsigned step = 0, unsigned stride = 0, ExternalSourceFileMode external_file_mode = ExternalSourceFileMode::NONE);
+              size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig = false, RocalBatchPolicy _last_batch_policy = RocalBatchPolicy::BATCH_FILL, bool last_batch_padded = false, 
+              const char *prefix = "", unsigned sequence_length = 0, unsigned step = 0, unsigned stride = 0, ExternalSourceFileMode external_file_mode = ExternalSourceFileMode::NONE);
 
     std::shared_ptr<LoaderModule> get_loader_module();
 

--- a/rocAL/include/loaders/image/node_image_loader_single_shard.h
+++ b/rocAL/include/loaders/image/node_image_loader_single_shard.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,7 @@ class ImageLoaderSingleShardNode : public Node {
     /// The loader will repeat images if necessary to be able to have images in multiples of the load_batch_count,
     /// for example if there are 10 images in the dataset and load_batch_count is 3, the loader repeats 2 images as if there are 12 images available.
     void init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type, DecoderType decoder_type,
-              bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig = false,
+              bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig = false, RocalBatchPolicy _last_batch_policy = RocalBatchPolicy::BATCH_FILL, bool last_batch_padded = false,
               const std::map<std::string, std::string> feature_key_map = std::map<std::string, std::string>(), unsigned sequence_length = 0, unsigned step = 0, unsigned stride = 0, ExternalSourceFileMode external_file_mode = ExternalSourceFileMode::NONE);
 
     std::shared_ptr<LoaderModule> get_loader_module();

--- a/rocAL/include/loaders/loader_module.h
+++ b/rocAL/include/loaders/loader_module.h
@@ -65,6 +65,7 @@ class LoaderModule {
     virtual void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                                      const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height,
                                      unsigned int channels, ExternalSourceFileMode mode, bool eos) = 0;
+    virtual size_t last_batch_padded_size() = 0;
 };
 
 using pLoaderModule = std::shared_ptr<LoaderModule>;

--- a/rocAL/include/loaders/video/video_loader.h
+++ b/rocAL/include/loaders/video/video_loader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -58,6 +58,7 @@ class VideoLoader : public LoaderModule {
     void shut_down() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override {}
+    size_t last_batch_padded_size() override;
 
    private:
     bool is_out_of_data();
@@ -89,5 +90,7 @@ class VideoLoader : public LoaderModule {
     std::vector<std::vector<std::vector<float>>> _sequence_frame_timestamps_vec;
     crop_image_info _crop_img_info;
     size_t _max_tensor_width, _max_tensor_height;
+    RocalBatchPolicy _last_batch_policy;
+    bool last_batch_padded;
 };
 #endif

--- a/rocAL/include/loaders/video/video_loader_sharded.h
+++ b/rocAL/include/loaders/video/video_loader_sharded.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ class VideoLoaderSharded : public LoaderModule {
     Timing timing() override;
     void feed_external_input(const std::vector<std::string>& input_images_names, const std::vector<unsigned char*>& input_buffer,
                              const std::vector<ROIxywh>& roi_xywh, unsigned int max_width, unsigned int max_height, unsigned int channels, ExternalSourceFileMode mode, bool eos) override {}
+    size_t last_batch_padded_size() override;
 
    private:
     void increment_loader_idx();

--- a/rocAL/include/loaders/video/video_read_and_decode.h
+++ b/rocAL/include/loaders/video/video_read_and_decode.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,7 @@ class VideoReadAndDecode {
 
     //! returns timing info or other status information
     Timing timing();
+    size_t last_batch_padded_size();
 
    private:
     struct video_map {

--- a/rocAL/include/pipeline/commons.h
+++ b/rocAL/include/pipeline/commons.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -153,4 +153,16 @@ struct Timing {
     long long unsigned video_read_time= 0;
     long long unsigned video_decode_time= 0;
     long long unsigned video_process_time= 0;
+};
+
+/*! \brief Tensor Last Batch Policies
+ These policies the last batch policies determine the behavior when there are not enough samples in the epoch to fill the last batch
+        FILL - The last batch is filled by either repeating the last sample or by wrapping up the data set.
+        DROP - The last batch is dropped if when there are not enough samples from the current epoch.
+        PARTIAL - The last batch is partially filled with the remaining data from the current epoch, keeping the rest of the samples empty. (currently this policy works similar to FILL in rocAL, PARTIAL policy needs to handled from python end)
+ */
+enum RocalBatchPolicy {
+    BATCH_FILL = 0,
+    DROP,
+    PARTIAL
 };

--- a/rocAL/include/pipeline/context.h
+++ b/rocAL/include/pipeline/context.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,12 @@ THE SOFTWARE.
 #include "master_graph.h"
 
 struct Context {
-    explicit Context(size_t batch_size, RocalAffinity affinity, int gpu_id, size_t cpu_thread_count, size_t prefetch_queue_depth, RocalTensorDataType output_tensor_type) : affinity(affinity),
-                                                                                                                                                                            _user_batch_size(batch_size) {
+    explicit Context(size_t batch_size, RocalAffinity affinity, int gpu_id, size_t cpu_thread_count, size_t prefetch_queue_depth, RocalTensorDataType output_tensor_type, RocalBatchPolicy last_batch_policy, bool last_batch_padded) : affinity(affinity),
+                                                                                                                                                                                                                                        last_batch_policy(last_batch_policy),
+                                                                                                                                                                                                                                        last_batch_padded(last_batch_padded),
+                                                                                                                                                                                                                                        _user_batch_size(batch_size) {
         LOG("Processing on " + STR(((affinity == RocalAffinity::CPU) ? " CPU" : " GPU")))
-        master_graph = std::make_shared<MasterGraph>(batch_size, affinity, cpu_thread_count, gpu_id, prefetch_queue_depth, output_tensor_type);
+        master_graph = std::make_shared<MasterGraph>(batch_size, affinity, cpu_thread_count, gpu_id, prefetch_queue_depth, output_tensor_type, last_batch_policy, last_batch_padded);
     }
     ~Context() {
         clear_errors();
@@ -38,6 +40,8 @@ struct Context {
     std::shared_ptr<MasterGraph> master_graph;
 
     RocalAffinity affinity;
+    RocalBatchPolicy last_batch_policy;
+    bool last_batch_padded;
     bool no_error() { return error.empty(); }
     const char* error_msg() { return error.c_str(); }
     void capture_error(const std::string& err_msg) { error = err_msg; }

--- a/rocAL/include/pipeline/master_graph.h
+++ b/rocAL/include/pipeline/master_graph.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -80,7 +80,7 @@ class MasterGraph {
                         NO_MORE_DATA = 2,
                         NOT_IMPLEMENTED = 3,
                         INVALID_ARGUMENTS };
-    MasterGraph(size_t batch_size, RocalAffinity affinity, size_t cpu_thread_count, int gpu_id, size_t prefetch_queue_depth, RocalTensorDataType output_tensor_data_type);
+    MasterGraph(size_t batch_size, RocalAffinity affinity, size_t cpu_thread_count, int gpu_id, size_t prefetch_queue_depth, RocalTensorDataType output_tensor_data_type, RocalBatchPolicy last_batch_policy, bool last_batch_padded);
     ~MasterGraph();
     Status reset();
     size_t remaining_count();
@@ -100,6 +100,9 @@ class MasterGraph {
     Status run();
     Timing timing();
     RocalMemType mem_type();
+    RocalBatchPolicy last_batch_policy();
+    bool last_batch_padded();
+    uint last_batch_padded_size();
     void release();
     template <typename T>
     std::shared_ptr<T> add_node(const std::vector<Tensor *> &inputs, const std::vector<Tensor *> &outputs);
@@ -223,6 +226,9 @@ class MasterGraph {
     BoxEncoderGpu *_box_encoder_gpu = nullptr;
 #endif
     TimingDBG _rb_block_if_empty_time, _rb_block_if_full_time;
+    RocalBatchPolicy _last_batch_policy; // Determines the handling of the last batch when the shard size is not divisible by the batch size. Check RocalLastBatchPolicy() enum for possible values
+    bool _last_batch_padded; // Determines whether the end of the data consists of data from the next shard (False) or is duplicated dummy data (True).
+    size_t _final_batch_padded_size; // Returns the size of the padded data
 };
 
 template <typename T>

--- a/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,8 @@ class Caffe2LMDBRecordReader : public Reader {
     int close() override;
 
     Caffe2LMDBRecordReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containnig the images

--- a/rocAL/include/readers/image/caffe_lmdb_record_reader.h
+++ b/rocAL/include/readers/image/caffe_lmdb_record_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,8 @@ class CaffeLMDBRecordReader : public Reader {
     int close() override;
 
     CaffeLMDBRecordReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containnig the images

--- a/rocAL/include/readers/image/cifar10_data_reader.h
+++ b/rocAL/include/readers/image/cifar10_data_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,8 @@ class CIFAR10DataReader : public Reader {
     CIFAR10DataReader();
 
     unsigned get_file_index() { return _last_file_idx; }
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containing the images

--- a/rocAL/include/readers/image/coco_file_source_reader.h
+++ b/rocAL/include/readers/image/coco_file_source_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,8 @@ class COCOFileSourceReader : public Reader {
     int close() override;
 
     COCOFileSourceReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;

--- a/rocAL/include/readers/image/file_list_reader.h
+++ b/rocAL/include/readers/image/file_list_reader.h
@@ -68,6 +68,8 @@ class FileListReader : public Reader {
 
     FileListReader();
 
+    size_t last_batch_padded_size() override;
+
    private:
     //! opens the folder containing the images
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;
@@ -97,6 +99,14 @@ class FileListReader : public Reader {
     int _read_counter = 0;
     //!< _file_count_all_shards total_number of files to figure out the max_batch_size (usually needed for distributed training).
     size_t _file_count_all_shards;
+    size_t _shard_count = 1; // equivalent of batch size
+    signed _shard_size = -1;
+    std::pair<RocalBatchPolicy, bool> _last_batch_info;
+    size_t _last_batch_padded_size = 0;
+    bool _stick_to_shard = false;
+    void generate_file_names();
+    //!<// Used to advance to the next shard's data to increase the entropy of the data seen by the pipeline>
+    void increment_shard_id();
     void increment_read_ptr();
     int release();
     size_t get_file_shard_id();

--- a/rocAL/include/readers/image/file_source_reader.h
+++ b/rocAL/include/readers/image/file_source_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,8 @@ class FileSourceReader : public Reader {
 
     FileSourceReader();
 
+    size_t last_batch_padded_size() override;
+
    private:
     //! opens the folder containnig the images
     Reader::Status open_folder();
@@ -94,6 +96,8 @@ class FileSourceReader : public Reader {
     int _read_counter = 0;
     //!< _file_count_all_shards total_number of files in to figure out the max_batch_size (usually needed for distributed training).
     size_t _file_count_all_shards;
+    std::pair<RocalBatchPolicy, bool> _last_batch_info;
+    size_t _last_batch_padded_size = 0;
     void incremenet_read_ptr();
     int release();
     size_t get_file_shard_id();

--- a/rocAL/include/readers/image/image_reader.h
+++ b/rocAL/include/readers/image/image_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,12 @@ struct ReaderConfig {
     void set_sequence_length(unsigned sequence_length) { _sequence_length = sequence_length; }
     void set_frame_step(unsigned step) { _sequence_frame_step = step; }
     void set_frame_stride(unsigned stride) { _sequence_frame_stride = stride; }
+    void set_last_batch_policy(RocalBatchPolicy last_batch_policy, bool last_batch_padded) {
+        _last_batch_policy = last_batch_policy;
+        _last_batch_padded = last_batch_padded;
+    }
+    void set_stick_to_shard(bool stick_to_shard) { _stick_to_shard = stick_to_shard; }
+    void set_shard_size(signed shard_size) { _shard_size = shard_size; }
     void set_external_filemode(ExternalSourceFileMode mode) { _file_mode = mode; }
     size_t get_shard_count() { return _shard_count; }
     size_t get_shard_id() { return _shard_id; }
@@ -99,6 +105,9 @@ struct ReaderConfig {
     std::string file_prefix() { return _file_prefix; }
     std::shared_ptr<MetaDataReader> meta_data_reader() { return _meta_data_reader; }
     ExternalSourceFileMode mode() { return _file_mode; }
+    std::pair<RocalBatchPolicy, bool> get_last_batch_policy() { return std::pair<RocalBatchPolicy, bool>(_last_batch_policy, _last_batch_padded); }
+    bool get_stick_to_shard() { return _stick_to_shard; }
+    signed get_shard_size() { return _shard_size; }
 
    private:
     StorageType _type = StorageType::FILE_SYSTEM;
@@ -117,6 +126,10 @@ struct ReaderConfig {
     std::string _file_prefix = "";  //!< to read only files with prefix. supported only for cifar10_data_reader and tf_record_reader
     std::shared_ptr<MetaDataReader> _meta_data_reader = nullptr;
     ExternalSourceFileMode _file_mode = ExternalSourceFileMode::NONE;
+    RocalBatchPolicy _last_batch_policy = RocalBatchPolicy::BATCH_FILL;
+    bool _last_batch_padded = false;
+    bool _stick_to_shard = false;
+    signed _shard_size = -1;
 #ifdef ROCAL_VIDEO
     VideoProperties _video_prop;
 #endif
@@ -179,4 +192,6 @@ class Reader {
     virtual unsigned count_items() = 0;
 
     virtual ~Reader() = default;
+
+    virtual size_t last_batch_padded_size() = 0;
 };

--- a/rocAL/include/readers/image/mxnet_recordio_reader.h
+++ b/rocAL/include/readers/image/mxnet_recordio_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,8 @@ class MXNetRecordIOReader : public Reader {
     int close() override;
 
     MXNetRecordIOReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containnig the images

--- a/rocAL/include/readers/image/tf_record_reader.h
+++ b/rocAL/include/readers/image/tf_record_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,8 @@ class TFRecordReader : public Reader {
     int close() override;
 
     TFRecordReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containnig the images

--- a/rocAL/include/readers/video/sequence_file_source_reader.h
+++ b/rocAL/include/readers/video/sequence_file_source_reader.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,8 @@ class SequenceFileSourceReader : public Reader {
     int close() override;
 
     SequenceFileSourceReader();
+
+    size_t last_batch_padded_size() override { return 0; }
 
    private:
     //! opens the folder containnig the images

--- a/rocAL/source/api/rocal_api_data_loaders.cpp
+++ b/rocAL/source/api/rocal_api_data_loaders.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -189,7 +189,8 @@ rocalJpegFileSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::FILE_SYSTEM, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::FILE_SYSTEM, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -385,7 +386,8 @@ rocalSequenceReaderSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::SEQUENCE_FILE_SYSTEM, DecoderType::TURBO_JPEG, shuffle, loop, context->master_graph->sequence_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, std::map<std::string, std::string>(), sequence_length, step, stride);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::SEQUENCE_FILE_SYSTEM, DecoderType::TURBO_JPEG, shuffle, loop, context->master_graph->sequence_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded(), std::map<std::string, std::string>(), sequence_length, step, stride);
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -505,7 +507,8 @@ rocalJpegCaffe2LMDBRecordSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::CAFFE2_LMDB_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::CAFFE2_LMDB_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -626,7 +629,8 @@ rocalJpegCaffeLMDBRecordSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::CAFFE_LMDB_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::CAFFE_LMDB_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -937,7 +941,8 @@ rocalMXNetRecordSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::MXNET_RECORDIO, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::MXNET_RECORDIO, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -1061,7 +1066,8 @@ rocalJpegCOCOFileSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, json_path, StorageType::COCO_FILE_SYSTEM, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original);
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, json_path, StorageType::COCO_FILE_SYSTEM, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), decoder_keep_original, context->master_graph->last_batch_policy(),
+                                                                                        context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -1336,6 +1342,7 @@ rocalJpegTFRecordSourceSingleShard(
     auto context = static_cast<Context*>(p_context);
     try {
         bool use_input_dimension = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE) || (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED);
+        bool decoder_keep_original = (decode_size_policy == ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED) || (decode_size_policy == ROCAL_USE_MAX_SIZE_RESTRICTED);
         DecoderType decType = DecoderType::TURBO_JPEG;  // default
         if (dec_type == ROCAL_DECODER_OPENCV) decType = DecoderType::OPENCV_DEC;
         if (dec_type == ROCAL_DECODER_HW_JPEG) decType = DecoderType::HW_JPEG_DEC;
@@ -1364,7 +1371,8 @@ rocalJpegTFRecordSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::TF_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader());
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::TF_RECORD, decType, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(),
+                                                                                        decoder_keep_original, context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -1422,7 +1430,7 @@ rocalRawTFRecordSource(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(1);
 
-        context->master_graph->add_node<ImageLoaderNode>({}, {output})->init(internal_shard_count, cpu_num_threads, source_path, "", feature_key_map, StorageType::TF_RECORD, DecoderType::SKIP_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), false, record_name_prefix, 0, 0, 0);
+        context->master_graph->add_node<ImageLoaderNode>({}, {output})->init(internal_shard_count, cpu_num_threads, source_path, "", feature_key_map, StorageType::TF_RECORD, DecoderType::SKIP_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), false, context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded(), record_name_prefix, 0, 0, 0);
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -1475,7 +1483,8 @@ rocalRawTFRecordSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
 
-        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::TF_RECORD, DecoderType::SKIP_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader());
+        context->master_graph->add_node<ImageLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::TF_RECORD, DecoderType::SKIP_DECODE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), 
+                                                                                        decoder_keep_original, context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -1534,7 +1543,7 @@ rocalFusedJpegCropSingleShard(
                                color_format);
         output = context->master_graph->create_loader_output_tensor(info);
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
-        context->master_graph->add_node<FusedJpegCropSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::FILE_SYSTEM, DecoderType::FUSED_TURBO_JPEG, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), num_attempts, area_factor, aspect_ratio);
+        context->master_graph->add_node<FusedJpegCropSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, "", StorageType::FILE_SYSTEM, DecoderType::FUSED_TURBO_JPEG, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), num_attempts, area_factor, aspect_ratio, context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded());
         context->master_graph->set_loop(loop);
 
         if (is_output) {
@@ -2126,7 +2135,7 @@ rocalAudioFileSourceSingleShard(
         output = context->master_graph->create_loader_output_tensor(info);
         output->reset_audio_sample_rate();
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(shard_count);
-        context->master_graph->add_node<AudioLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType(storage_type), DecoderType::SNDFILE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader());
+        context->master_graph->add_node<AudioLoaderSingleShardNode>({}, {output})->init(shard_id, shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType(storage_type), DecoderType::SNDFILE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded(), stick_to_shard, shard_size);
         context->master_graph->set_loop(loop);
         if (downmix) {
             TensorInfo output_info = info;
@@ -2167,7 +2176,9 @@ rocalAudioFileSource(
     bool loop,
     bool downmix,
     unsigned max_frames,
-    unsigned max_channels) {
+    unsigned max_channels,
+    bool stick_to_shard,
+    int shard_size) {
     Tensor* output = nullptr;
     auto context = static_cast<Context*>(p_context);
     try {
@@ -2183,7 +2194,7 @@ rocalAudioFileSource(
         output = context->master_graph->create_loader_output_tensor(info);
         output->reset_audio_sample_rate();
         auto cpu_num_threads = context->master_graph->calculate_cpu_num_threads(internal_shard_count);
-        context->master_graph->add_node<AudioLoaderNode>({}, {output})->init(internal_shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::SNDFILE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader());
+        context->master_graph->add_node<AudioLoaderNode>({}, {output})->init(internal_shard_count, cpu_num_threads, source_path, source_file_list_path, StorageType::FILE_SYSTEM, DecoderType::SNDFILE, shuffle, loop, context->user_batch_size(), context->master_graph->mem_type(), context->master_graph->meta_data_reader(), context->master_graph->meta_data_reader(), context->master_graph->last_batch_policy(), context->master_graph->last_batch_padded(), stick_to_shard, shard_size);
         context->master_graph->set_loop(loop);
         if (downmix) {
             TensorInfo output_info = info;

--- a/rocAL/source/api/rocal_api_info.cpp
+++ b/rocAL/source/api/rocal_api_info.cpp
@@ -163,3 +163,18 @@ size_t ROCAL_API_CALL rocalIsEmpty(RocalContext p_context) {
     }
     return ret;
 }
+
+size_t  ROCAL_API_CALL
+rocalGetLastBatchPaddedSize(RocalContext p_context) {
+    auto context = static_cast<Context *>(p_context);
+    size_t count = 0;
+    try {
+        count = context->master_graph->last_batch_padded_size();
+    }
+    catch (const std::exception &e) {
+        context->capture_error(e.what());
+        ERR(e.what());
+    }
+    return count;
+}
+

--- a/rocAL/source/loaders/audio/audio_loader.cpp
+++ b/rocAL/source/loaders/audio/audio_loader.cpp
@@ -204,6 +204,10 @@ bool AudioLoader::is_out_of_data() {
     return (remaining_count() < 0);
 }
 
+size_t AudioLoader::last_batch_padded_size() {
+    return _audio_loader->last_batch_padded_size();
+}
+
 LoaderModuleStatus
 AudioLoader::update_output_audio() {
     LoaderModuleStatus status = LoaderModuleStatus::OK;

--- a/rocAL/source/loaders/audio/audio_loader_sharded.cpp
+++ b/rocAL/source/loaders/audio/audio_loader_sharded.cpp
@@ -46,6 +46,13 @@ AudioLoaderSharded::~AudioLoaderSharded() {
     _loaders.clear();
 }
 
+size_t AudioLoaderSharded::last_batch_padded_size() {
+    size_t sum = 0;
+    for (auto& loader : _loaders)
+        sum += loader->last_batch_padded_size();
+    return sum;
+}
+
 void AudioLoaderSharded::fast_forward_through_empty_loaders() {
     int loaders_count = _loaders.size();
     // reject empty loaders and get to a loader that still has audios to play

--- a/rocAL/source/loaders/audio/audio_read_and_decode.cpp
+++ b/rocAL/source/loaders/audio/audio_read_and_decode.cpp
@@ -76,6 +76,11 @@ AudioReadAndDecode::count() {
     return _reader->count_items();
 }
 
+size_t
+AudioReadAndDecode::last_batch_padded_size() {
+    return _reader->last_batch_padded_size();
+}
+
 LoaderModuleStatus
 AudioReadAndDecode::load(float *buff,
                          std::vector<std::string> &names,

--- a/rocAL/source/loaders/audio/node_audio_loader.cpp
+++ b/rocAL/source/loaders/audio/node_audio_loader.cpp
@@ -29,7 +29,8 @@ AudioLoaderNode::AudioLoaderNode(Tensor *output, void *device_resources) : Node(
 }
 
 void AudioLoaderNode::init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &source_list_path, StorageType storage_type,
-                           DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader) {
+                           DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
+                           RocalBatchPolicy _last_batch_policy, bool last_batch_padded, bool stick_to_shard, signed shard_size) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for AudioLoaderNode, cannot initialize")
     if (internal_shard_count < 1)
@@ -41,6 +42,8 @@ void AudioLoaderNode::init(unsigned internal_shard_count, unsigned cpu_num_threa
     reader_cfg.set_batch_count(load_batch_count);
     reader_cfg.set_meta_data_reader(meta_data_reader);
     reader_cfg.set_cpu_num_threads(cpu_num_threads);
+    reader_cfg.set_stick_to_shard(stick_to_shard);
+    reader_cfg.set_shard_size(shard_size);
     _loader_module->initialize(reader_cfg, DecoderConfig(decoder_type), mem_type, _batch_size, false);
     _loader_module->start_loading();
 }

--- a/rocAL/source/loaders/audio/node_audio_loader_single_shard.cpp
+++ b/rocAL/source/loaders/audio/node_audio_loader_single_shard.cpp
@@ -29,7 +29,7 @@ AudioLoaderSingleShardNode::AudioLoaderSingleShardNode(Tensor *output, void *dev
 
 void AudioLoaderSingleShardNode::init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &source_list_path,
                                       StorageType storage_type, DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count,
-                                      RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader) {
+                                      RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, RocalBatchPolicy last_batch_policy, bool last_batch_padded, bool stick_to_shard, signed shard_size) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for AudioLoaderNode, cannot initialize")
     if (shard_count < 1)
@@ -44,6 +44,9 @@ void AudioLoaderSingleShardNode::init(unsigned shard_id, unsigned shard_count, u
     reader_cfg.set_batch_count(load_batch_count);
     reader_cfg.set_meta_data_reader(meta_data_reader);
     reader_cfg.set_cpu_num_threads(cpu_num_threads);
+    reader_cfg.set_last_batch_policy(last_batch_policy, last_batch_padded);
+    reader_cfg.set_stick_to_shard(stick_to_shard);
+    reader_cfg.set_shard_size(shard_size);
     _loader_module->initialize(reader_cfg, DecoderConfig(decoder_type), mem_type, _batch_size);
     _loader_module->start_loading();
 }

--- a/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/source/loaders/image/image_loader.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -233,6 +233,11 @@ ImageLoader::load_routine() {
 bool ImageLoader::is_out_of_data() {
     return (remaining_count() < _batch_size);
 }
+
+size_t ImageLoader::last_batch_padded_size() {
+    return _image_loader->last_batch_padded_size();
+}
+
 LoaderModuleStatus
 ImageLoader::update_output_image() {
     LoaderModuleStatus status = LoaderModuleStatus::OK;

--- a/rocAL/source/loaders/image/image_loader_sharded.cpp
+++ b/rocAL/source/loaders/image/image_loader_sharded.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -113,6 +113,13 @@ void ImageLoaderSharded::start_loading() {
         _loaders[i]->set_cpu_affinity(cpuset);
 #endif
     }
+}
+
+size_t ImageLoaderSharded::last_batch_padded_size() {
+    size_t sum = 0;
+    for(auto& loader: _loaders)
+        sum += loader->last_batch_padded_size();
+    return sum;
 }
 
 void ImageLoaderSharded::shut_down() {

--- a/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -137,6 +137,11 @@ void ImageReadAndDecode::set_random_bbox_data_reader(std::shared_ptr<RandomBBoxC
     _randombboxcrop_meta_data_reader = randombboxcrop_meta_data_reader;
 }
 
+size_t
+ImageReadAndDecode::last_batch_padded_size() {
+    return _reader->last_batch_padded_size();
+}
+
 std::vector<std::vector<float>>&
 ImageReadAndDecode::get_batch_random_bbox_crop_coords() {
     // Return the crop co-ordinates for a batch of images

--- a/rocAL/source/loaders/image/node_fused_jpeg_crop.cpp
+++ b/rocAL/source/loaders/image/node_fused_jpeg_crop.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@ FusedJpegCropNode::FusedJpegCropNode(Tensor *output, void *device_resources) : N
 
 void FusedJpegCropNode::init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type,
                              DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
-                             unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio) {
+                             unsigned num_attempts, std::vector<float> &random_area, std::vector<float> &random_aspect_ratio, RocalBatchPolicy _last_batch_policy, bool last_batch_padded) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for FusedJpegCropNode, cannot initialize")
     if (internal_shard_count < 1)

--- a/rocAL/source/loaders/image/node_fused_jpeg_crop_single_shard.cpp
+++ b/rocAL/source/loaders/image/node_fused_jpeg_crop_single_shard.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@ FusedJpegCropSingleShardNode::FusedJpegCropSingleShardNode(Tensor *output, void 
 
 void FusedJpegCropSingleShardNode::init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type,
                                         DecoderType decoder_type, bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
-                                        unsigned num_attempts, std::vector<float> &area_factor, std::vector<float> &aspect_ratio) {
+                                        unsigned num_attempts, std::vector<float> &area_factor, std::vector<float> &aspect_ratio, RocalBatchPolicy _last_batch_policy, bool last_batch_padded) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for FusedJpegCropSingleShardNode, cannot initialize")
     if (shard_count < 1)

--- a/rocAL/source/loaders/image/node_image_loader.cpp
+++ b/rocAL/source/loaders/image/node_image_loader.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ ImageLoaderNode::ImageLoaderNode(Tensor *output, void *device_resources) : Node(
 }
 
 void ImageLoaderNode::init(unsigned internal_shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, const std::map<std::string, std::string> feature_key_map, StorageType storage_type, DecoderType decoder_type, bool shuffle, bool loop,
-                           size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig, const char *file_prefix, unsigned sequence_length, unsigned step, unsigned stride, ExternalSourceFileMode external_file_mode) {
+                           size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader, bool decoder_keep_orig, RocalBatchPolicy last_batch_policy, bool last_batch_padded, const char *file_prefix, unsigned sequence_length, unsigned step, unsigned stride, ExternalSourceFileMode external_file_mode) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for ImageLoaderNode, cannot initialize")
     if (internal_shard_count < 1)
@@ -47,6 +47,7 @@ void ImageLoaderNode::init(unsigned internal_shard_count, unsigned cpu_num_threa
     reader_cfg.set_frame_step(step);
     reader_cfg.set_frame_stride(stride);
     reader_cfg.set_external_filemode(external_file_mode);
+    reader_cfg.set_last_batch_policy(last_batch_policy, last_batch_padded);
     _loader_module->initialize(reader_cfg, DecoderConfig(decoder_type),
                                mem_type,
                                _batch_size, decoder_keep_orig);

--- a/rocAL/source/loaders/image/node_image_loader_single_shard.cpp
+++ b/rocAL/source/loaders/image/node_image_loader_single_shard.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@ ImageLoaderSingleShardNode::ImageLoaderSingleShardNode(Tensor *output, void *dev
 
 void ImageLoaderSingleShardNode::init(unsigned shard_id, unsigned shard_count, unsigned cpu_num_threads, const std::string &source_path, const std::string &json_path, StorageType storage_type, DecoderType decoder_type,
                                       bool shuffle, bool loop, size_t load_batch_count, RocalMemType mem_type, std::shared_ptr<MetaDataReader> meta_data_reader,
-                                      bool decoder_keep_original, const std::map<std::string, std::string> feature_key_map, unsigned sequence_length, unsigned step, unsigned stride, ExternalSourceFileMode external_file_mode) {
+                                      bool decoder_keep_original, RocalBatchPolicy last_batch_policy, bool last_batch_padded, const std::map<std::string, std::string> feature_key_map, unsigned sequence_length, unsigned step, unsigned stride, ExternalSourceFileMode external_file_mode) {
     if (!_loader_module)
         THROW("ERROR: loader module is not set for ImageLoaderNode, cannot initialize")
     if (shard_count < 1)
@@ -50,6 +50,7 @@ void ImageLoaderSingleShardNode::init(unsigned shard_id, unsigned shard_count, u
     reader_cfg.set_frame_step(step);
     reader_cfg.set_frame_stride(stride);
     reader_cfg.set_external_filemode(external_file_mode);
+    reader_cfg.set_last_batch_policy(last_batch_policy, last_batch_padded);
     _loader_module->initialize(reader_cfg, DecoderConfig(decoder_type),
                                mem_type,
                                _batch_size, decoder_keep_original);

--- a/rocAL/source/loaders/video/video_loader.cpp
+++ b/rocAL/source/loaders/video/video_loader.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -208,6 +208,10 @@ bool VideoLoader::is_out_of_data() {
     return (remaining_count() < _batch_size);
 }
 
+size_t VideoLoader::last_batch_padded_size() {
+    return _video_loader->last_batch_padded_size();
+}
+
 LoaderModuleStatus
 VideoLoader::update_output_image() {
     LoaderModuleStatus status = LoaderModuleStatus::OK;
@@ -294,4 +298,12 @@ std::vector<std::vector<float>> VideoLoader::get_sequence_frame_timestamps() {
     _sequence_frame_timestamps_vec.pop_back();
     return sequence_frame_timestamp;
 }
+
+size_t VideoLoaderSharded::last_batch_padded_size() {
+    size_t sum = 0;
+    for (auto &loader : _loaders)
+        sum += loader->last_batch_padded_size();
+    return sum;
+}
+
 #endif

--- a/rocAL/source/loaders/video/video_read_and_decode.cpp
+++ b/rocAL/source/loaders/video/video_read_and_decode.cpp
@@ -125,6 +125,12 @@ void VideoReadAndDecode::decode_sequence(size_t sequence_index) {
     }
 }
 
+//For video loader , the support for last batch policy is not added.
+size_t
+VideoReadAndDecode::last_batch_padded_size() {
+    return 0;
+}
+
 LoaderModuleStatus
 VideoReadAndDecode::load(unsigned char *buff,
                          std::vector<std::string> &names,

--- a/rocAL_pybind/amd/rocal/types.py
+++ b/rocAL_pybind/amd/rocal/types.py
@@ -110,6 +110,9 @@ from rocal_pybind.types import PAD
 from rocal_pybind.types import TRIMTOSHAPE
 from rocal_pybind.types import ERROR
 
+from rocal_pybind.types import LAST_BATCH_FILL
+from rocal_pybind.types import LAST_BATCH_DROP
+from rocal_pybind.types import LAST_BATCH_PARTIAL
 
 _known_types = {
 
@@ -175,6 +178,10 @@ _known_types = {
     ZERO: ("ZERO", ZERO),
     CLAMP: ("CLAMP", CLAMP),
     REFLECT: ("REFLECT", REFLECT),
+    
+    LAST_BATCH_FILL : ("LAST_BATCH_FILL", LAST_BATCH_FILL),
+    LAST_BATCH_DROP : ("LAST_BATCH_DROP", LAST_BATCH_DROP),
+    LAST_BATCH_PARTIAL : ("LAST_BATCH_PARTIAL", LAST_BATCH_PARTIAL),
 }
 
 def data_type_function(dtype):

--- a/rocAL_pybind/examples/rocAL_api_audio_unittest.py
+++ b/rocAL_pybind/examples/rocAL_api_audio_unittest.py
@@ -54,10 +54,10 @@ def main():
     device_id = 0
     random_seed = random.SystemRandom().randint(0, 2**32 - 1)
     print("*********************************************************************")
-    audio_pipeline = Pipeline(batch_size=batch_size, num_threads=num_threads, device_id=device_id, seed=random_seed, rocal_cpu=rocal_cpu)
+    audio_pipeline = Pipeline(batch_size=batch_size, num_threads=num_threads, device_id=device_id, seed=random_seed, rocal_cpu=rocal_cpu, last_batch_policy=types.LAST_BATCH_FILL, last_batch_padded=True)
     with audio_pipeline:
         audio, label = fn.readers.file(file_root=data_path, file_list=file_list)
-        audio_decode = fn.decoders.audio(audio, file_root=data_path, file_list_path=file_list, downmix=True, shard_id=0, num_shards=1, storage_type=10, stick_to_shard=False)
+        audio_decode = fn.decoders.audio(audio, file_root=data_path, file_list_path=file_list, downmix=True, shard_id=0, num_shards=1, storage_type=10, stick_to_shard=False, shard_size=-1)
         begin, length = fn.nonsilent_region(audio_decode, cutoff_db=-60)
         pre_emphasis_filter = fn.preemphasis_filter(audio_decode)
         spec = fn.spectrogram(

--- a/rocAL_pybind/rocal_pybind.cpp
+++ b/rocAL_pybind/rocal_pybind.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2019 - 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -150,14 +150,7 @@ PYBIND11_MODULE(rocal_pybind, m) {
     m.doc() = "Python bindings for the C++ portions of ROCAL";
     // Bind the C++ structure
     // rocal_api.h
-    m.def("rocalCreate", &rocalCreate, "Creates context with the arguments sent and returns it",
-          py::return_value_policy::reference,
-          py::arg("batch_size"),
-          py::arg("affinity"),
-          py::arg("gpu_id") = 0,
-          py::arg("cpu_thread_count") = 1,
-          py::arg("prefetch_queue_depth") = 3,
-          py::arg("output_data_type") = 0);
+    m.def("rocalCreate", &rocalCreate, "Creates context with the arguments sent and returns it", py::return_value_policy::reference);
     m.def("rocalVerify", &rocalVerify);
     m.def("rocalRun", &rocalRun, py::return_value_policy::reference);
     m.def("rocalRelease", &rocalRelease, py::return_value_policy::reference);
@@ -414,6 +407,11 @@ PYBIND11_MODULE(rocal_pybind, m) {
         .value("TRIMTOSHAPE", TRIMTOSHAPE)
         .value("ERROR", ERROR)
         .export_values();
+    py::enum_<RocalLastBatchPolicy>(types_m, "RocalLastBatchPolicy", "Rocal Last Batch Policy")
+            .value("LAST_BATCH_FILL",ROCAL_LAST_BATCH_FILL)
+            .value("LAST_BATCH_DROP",ROCAL_LAST_BATCH_DROP)
+            .value("LAST_BATCH_PARTIAL",ROCAL_LAST_BATCH_PARTIAL)
+            .export_values();
     py::class_<ROIxywh>(m, "ROIxywh")
         .def(py::init<>())
         .def_readwrite("x", &ROIxywh::x)
@@ -444,6 +442,8 @@ PYBIND11_MODULE(rocal_pybind, m) {
     m.def("getTimingInfo", &rocalGetTimingInfo);
     m.def("labelReader", &rocalCreateLabelReader, py::return_value_policy::reference);
     m.def("cocoReader", &rocalCreateCOCOReader, py::return_value_policy::reference);
+    m.def("getRemainingImages", &rocalGetRemainingImages, py::return_value_policy::reference);
+    m.def("getLastBatchPaddedSize", &rocalGetLastBatchPaddedSize, py::return_value_policy::reference);
     // rocal_api_meta_data.h
     m.def("randomBBoxCrop", &rocalRandomBBoxCrop);
     m.def("boxEncoder", &rocalBoxEncoder);


### PR DESCRIPTION
 Audio PR 7 : Last Batch Policy, stick_to_shard, shard_size & auto_reset
    Changes for last batch policy is introduced in this PR for audio pipeline
    The variables shard_size, auto_reset have been introduced and incorporated in the iterator
    The variable stick_to_shard and shard_size has been added as a part of the reader_cfg to reset() the data when shard_size >0 and stick_to_shard is False (to increase the overall entropy of the dataset across different shards) for audio pipeline
